### PR TITLE
bam-5/fixed navigation errors

### DIFF
--- a/bambinomio/assets/html/kokvilnas_autini.html
+++ b/bambinomio/assets/html/kokvilnas_autini.html
@@ -1,28 +1,28 @@
 <!DOCTYPE html>
-<div id="kokvilnas-autini" class="w3-content" >
+<div id="kokvilnas-autini" class="w3-content w3-container w3-padding-64" >
     <h2>Viss, kas jums jāzina, lai sāktu ceļojumu ar auduma autiņiem.</h2>
     <h3>Kas ir autiņu bambinomio auduma autiņi?</h3>
     <h5>Auduma autiņi ir autiņi, kurus neizmetat. Tie ir paredzēti atkārtotai izmantošanai un ir izgatavoti no īpaši
       mīksta auduma, nevis plastmasas, ko var atrast vienreizējās lietošanas autiņos. Auduma autiņbiksītes var saukt
       par dažādām lietām, piemēram, “atkārtoti lietojamām autiņbiksītēm” vai “mazgājamām autiņbiksītēm”, taču tas viss
       nozīmē vienu un to pašu!</h5>
-    <img src="./assets/img/diapers.png">
+    <img src="./assets/img/diapers.png" style="width:100%">
     <h3>Kāpēc izvelēties tieši bambinomio autiņus?</h3>
     <h5>Arvien vairāk vecāku izvēlas bērnam izmantot auduma autiņbiksītes. Mūsu autiņi jūtas labāk: labāki gan
       pakaļiem, gan kabatai un arī mūsu planētai. Mūsu produkti ir brīnišķīgi, var ietaupīt naudu, ir draudzīgi
       planētai un arī izskatās ļoti jauki!</h5>
-    <img src="./assets/img/diapers2.png">
+    <img src="./assets/img/diapers2.png" style="width:100%">
     <h3>Kā tie strādā?</h3>
     <h5>Auduma autiņi darbojas tieši tāpat kā citi autiņi. Vienīgā atšķirība ir tāda, ka, mainot laiku, nomainiet
       autiņu veļas mazgāšanas dienai, nevis izmetiet to. Tos ir viegli lietot, un ir daži soli pa solim padomi, ar
       kuriem mēs dalīsimies ar jums, lai palīdzētu izmantot mūsu produktus, kad sākat ceļojumu ar auduma
       autiņbiksītēm.</h5>
-    <img src="./assets/img/diapers3.png">
+    <img src="./assets/img/diapers3.png" style="width:100%">
     <h2>Kas jums ir nepieciešams?</h2>
     <h3>Nepieciešamais ir atkarīgs no tā, vai plānojat būt pilna vai nepilna laika auduma autiņu lietotājs. Sākumā mēs
       iesakām jums pietikt ar autiņbiksītēm 2 dienu autiņbiksīšu nomaiņas vērtībā, lai jums būtu pietiekami daudz
       autiņu, ko lietot, kamēr citi mazgājas, žāvē un ir gatavi lietošanai vēlreiz! Mēs arī iesakām pirms mazgāšanas
       izvēlēties vietu, kur uzglabāt netīros autiņus. Un neaizmirstiet, ka jums būs nepieciešama jūsu veļas mašīna!
     </h3>
-    <img src="./assets/img/diapers3.png">
+    <img src="./assets/img/diapers3.png" style="width:100%">
   </div>

--- a/bambinomio/assets/html/navigation.html
+++ b/bambinomio/assets/html/navigation.html
@@ -4,9 +4,11 @@
   <div class="w3-bar w3-theme w3-card">
     <a class="w3-bar-item w3-button w3-padding-large w3-hide-medium w3-hide-large w3-right" href="javascript:void(0)"
       onclick="toggleNavBar()" title="Toggle Navigation Menu"><i class="fa fa-bars"></i></a>
-    <a href="#" class="w3-bar-item w3-button ">Sākums</a>
+    <div class="w3-dropdown-hover">
+      <button class="w3-button" onclick="location.href='#';">Sākums</button>
+    </div>
     <div class="w3-dropdown-hover w3-hide-small">
-        <button class="w3-button" onclick="location.href='#kokvilnas-autini';">Kokvilnas autiņi</button>
+      <button class="w3-button" onclick="location.href='#kokvilnas-autini';">Kokvilnas autiņi</button>
       <div class="w3-dropdown-content  w3-bar-block w3-border">
         <a href="#" class="w3-bar-item w3-button">Mio Solo-viss vienā autiņā</a>
         <a href="#" class="w3-bar-item w3-button">Divdaļīgie autiņi </a>
@@ -20,7 +22,7 @@
         <a href="#" class="w3-bar-item w3-button">Peldcepures</a>
         <a href="#" class="w3-bar-item w3-button">Mitrumizturīgās somas</a>
       </div>
-    </div>   
+    </div>
     <div class="w3-dropdown-hover w3-hide-small">
       <button class="w3-button ">Podiņapmācība</button>
       <div class="w3-dropdown-content w3-bar-block w3-border">
@@ -29,10 +31,10 @@
         <a href="#" class="w3-bar-item w3-button">Mio Stem-pakāpiens</a>
         <a href="#" class="w3-bar-item w3-button">Mio Seat-poda paliknis</a>
       </div>
-    </div>       
+    </div>
     <div class="w3-dropdown-hover w3-hide-small">
       <button class="w3-button ">Piederumi</button>
-      <div class="w3-dropdown-content w3-bar-block w3-border" >
+      <div class="w3-dropdown-content w3-bar-block w3-border">
         <a href="#bio_sairstosas_salvetes" class="w3-bar-item w3-button">Bio Sairstošās salvetes</a>
         <a href="#tiramaisl" class="w3-bar-item w3-button">Mio Fresh-autiņu tīrāmais līdzeklis</a>
         <a href="#pulveris" class="w3-bar-item w3-button">Mio Care-veļas mazgājamais pulveris</a>
@@ -46,11 +48,13 @@
 </div>
 
 <!-- Navbar on small screens (remove the onclick attribute if you want the navbar to always show on top of the content when clicking on the links) -->
-<div id="navig-small-screens" class="w3-bar-block w3-theme w3-hide w3-hide-large w3-hide-medium w3-top" style="margin-top:46px">
+<div id="navig-small-screens" class="w3-bar-block w3-theme w3-hide w3-hide-large w3-hide-medium w3-top"
+  style="margin-top:46px">
 
   <div class="w3-dropdown-hover w3-bar-item">
-    <button class="w3-button w3-padding-large" onclick="toggleNavBar();location.href='#kokvilnas-autini';">Kokvilnas autiņi</button>
+    <button class="w3-button w3-padding-large" onclick="toggleNavBar();">Kokvilnas autiņi</button>
     <div class="w3-dropdown-content  w3-bar-block w3-border">
+      <a href="#kokvilnas-autini" class="w3-bar-item w3-button" onclick="toggleNavBar()">Apraksts</a>
       <a href="#" class="w3-bar-item w3-button" onclick="toggleNavBar()">Mio Solo-viss vienā autiņā</a>
       <a href="#" class="w3-bar-item w3-button" onclick="toggleNavBar()">Divdaļīgie autiņi </a>
       <a href="#" class="w3-bar-item w3-button" onclick="toggleNavBar()">Bio sairstošie ielikņi</a>
@@ -63,7 +67,7 @@
       <a href="#" class="w3-bar-item w3-button" onclick="toggleNavBar()">Peldcepures</a>
       <a href="#" class="w3-bar-item w3-button" onclick="toggleNavBar()">Mitrumizturīgās somas</a>
     </div>
-  </div>   
+  </div>
   <div class="w3-dropdown-hover w3-bar-item">
     <button class="w3-button  w3-padding-large">Podiņapmācība</button>
     <div class="w3-dropdown-content w3-bar-block w3-border">
@@ -72,16 +76,19 @@
       <a href="#" class="w3-bar-item w3-button" onclick="toggleNavBar()">Mio Stem-pakāpiens</a>
       <a href="#" class="w3-bar-item w3-button" onclick="toggleNavBar()">Mio Seat-poda paliknis</a>
     </div>
-  </div>       
+  </div>
   <div class="w3-dropdown-hover w3-bar-item">
     <button class="w3-button  w3-padding-large">Piederumi</button>
-    <div class="w3-dropdown-content w3-bar-block w3-border" >
-      <a href="#bio_sairstosas_salvetes" class="w3-bar-item w3-button">Bio Sairstošās salvetes</a>
-      <a href="#tiramaisl" class="w3-bar-item w3-button">Mio Fresh-autiņu tīrāmais līdzeklis</a>
-      <a href="#pulveris" class="w3-bar-item w3-button">Mio Care-veļas mazgājamais pulveris</a>
-      <a href="#musilina" class="w3-bar-item w3-button">Muslīna drāniņas</a>
-      <a href="./assets/html/maisins.html" class="w3-bar-item w3-button">Veļas maisiņi</a>
-      <a href="./assets/html/palags.html" class="w3-bar-item w3-button">Aizsargpalags matracim</a>
+    <div class="w3-dropdown-content w3-bar-block w3-border">
+      <a href="#bio_sairstosas_salvetes" class="w3-bar-item w3-button" onclick="toggleNavBar()">Bio Sairstošās
+        salvetes</a>
+      <a href="#tiramaisl" class="w3-bar-item w3-button" onclick="toggleNavBar()">Mio Fresh-autiņu tīrāmais
+        līdzeklis</a>
+      <a href="#pulveris" class="w3-bar-item w3-button" onclick="toggleNavBar()">Mio Care-veļas mazgājamais pulveris</a>
+      <a href="#musilina" class="w3-bar-item w3-button" onclick="toggleNavBar()">Muslīna drāniņas</a>
+      <a href="./assets/html/maisins.html" class="w3-bar-item w3-button" onclick="toggleNavBar()">Veļas maisiņi</a>
+      <a href="./assets/html/palags.html" class="w3-bar-item w3-button" onclick="toggleNavBar()">Aizsargpalags
+        matracim</a>
     </div>
   </div>
 

--- a/bambinomio/assets/html/salvetes.html
+++ b/bambinomio/assets/html/salvetes.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <div id="bio_sairstosas_salvetes" class="w3-padding-large">
+  <div id="bio_sairstosas_salvetes" class="w3-padding-64 ">
     <style>
       .card {
         box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);

--- a/bambinomio/index.html
+++ b/bambinomio/index.html
@@ -24,17 +24,18 @@
   <div class="w3-text-theme w3-panel w3-content w3-padding-64" style="max-width:2000px">
 
     <!-- introduction -->
-    <div class="w3-row w3-padding-32">
-      <div class="w3-left">
-        <img src="assets/img/logo.png" class="w3-round w3-margin-bottom" alt="logo" style="width:100%">
+    <div class="w3-row">
+      <div class="w3-container w3-quarter ">
+        <img src="assets/img/logo.png" class="w3-round w3-margin-bottom" alt="logo" style="width:70%">
       </div>
-      <ul class="w3-ul w3-center w3-padding-64">
-        <li>atkārtoti lietojamie autiņi</li>
-        <li>draudzīgs bērnam</li>
-        <li>draudzīgs videi</li>
-        <li>draudzīgs makam</li>
-      </ul>
-
+      <div class="w3-container w3-threequarter ">
+        <ul class="w3-ul w3-center ">
+          <li><h2>atkārtoti lietojamie autiņi</h2></li>
+          <li><h2>draudzīgs bērnam</h2></li>
+          <li><h2>draudzīgs videi</h2></li>
+          <li><h2>draudzīgs makam</h2></li>
+        </ul>
+      </div>
     </div>
 
     <div w3-include-html="assets/html/kokvilnas_autini.html"></div>

--- a/bambinomio/index.html
+++ b/bambinomio/index.html
@@ -21,7 +21,7 @@
   <div w3-include-html="assets/html/navigation.html"></div>
 
   <!-- Page content -->
-  <div class="w3-text-theme w3-panel" style="max-width:2000px;margin-top:56px">
+  <div class="w3-text-theme w3-panel w3-content w3-padding-64" style="max-width:2000px">
 
     <!-- introduction -->
     <div class="w3-row w3-padding-32">


### PR DESCRIPTION
### Izmaiņas lapā: 

- Pie bildēm pievienots  style="width:100%" , bez tā navigācijas ikona uz mobilā telefona rādījās pa labi ārpus ekrāna. 
- Pievienots Vēl vines punkts “apraksts“ autiņiem (tikai  mobilā telefona navigācijā) - bez tā nebija skaidra navigācijas loģika “bez peles“. 
- lapas saturs uz mobilā telefona “lien zem navigācijas joslas“ - pieliku w3-padding-64
- Piederumiem mobilajā navigācijā pēc izveles izdarīšanas nepazūd menu. - pieliku onclick="toggleNavBar()"
- Lielā ekrāna navigācijā sākuma poga pacēlusies uz augšu.  → salabots

### Emīlijas izmaiņas
- pieliktas klāt šeit pat, jo Emīlijai bija problēmas ar git setup. Izmainīta galva (ievads) 